### PR TITLE
Fix write_files content indentation in cloud-init templates

### DIFF
--- a/templates/k3s-agent.yaml.tftpl
+++ b/templates/k3s-agent.yaml.tftpl
@@ -22,14 +22,14 @@ write_files:
     owner: root:root
     permissions: "0640"
     content: |
-${indent(6, agent_config_yaml)}
+      ${indent(6, agent_config_yaml)}
 %{ endif ~}
 %{ for path, content in agent_files ~}
   - path: ${path}
     owner: root:root
     permissions: "0640"
     content: |
-${indent(6, content)}
+      ${indent(6, content)}
 %{ endfor ~}
 %{ endif ~}
 runcmd:

--- a/templates/k3s-server.yaml.tftpl
+++ b/templates/k3s-server.yaml.tftpl
@@ -22,14 +22,14 @@ write_files:
     owner: root:root
     permissions: "0640"
     content: |
-${indent(6, server_config_yaml)}
+      ${indent(6, server_config_yaml)}
 %{ endif ~}
 %{ for path, content in server_files ~}
   - path: ${path}
     owner: root:root
     permissions: "0640"
     content: |
-${indent(6, content)}
+      ${indent(6, content)}
 %{ endfor ~}
 %{ endif ~}
 runcmd:


### PR DESCRIPTION
## Summary
- Fix `indent()` usage in cloud-init templates — first line was at column 0 instead of indented under `content: |`
- Terraform's `indent(n, str)` does NOT indent the first line, so we need leading spaces before the interpolation
- This caused k3s to receive malformed `config.yaml`, `audit.yaml`, and `psa.yaml` files

## Root cause
`${indent(6, server_config_yaml)}` was at column 0 in the template. Changed to `      ${indent(6, server_config_yaml)}` (6 spaces prefix) so the first line is also indented.

## Test plan
- [ ] `tofu test` passes
- [ ] Inspect rendered cloud-init snippet on Proxmox — all `content: |` blocks properly indented
- [ ] k3s starts successfully with hardened config

🤖 Generated with [Claude Code](https://claude.com/claude-code)