### PR TITLE
Enable QEMU guest agent on k3s nodes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "proxmox_virtual_environment_file" "cloud_init_agent" {
 }
 
 module "control_plane" {
-  source = "git::https://github.com/n2solutionsio/terraform-proxmox-vm.git?ref=v0.3.0"
+  source = "git::https://github.com/n2solutionsio/terraform-proxmox-vm.git?ref=v0.4.0"
   count  = var.control_plane_count
 
   node_name      = var.node_name
@@ -79,6 +79,8 @@ module "control_plane" {
   vlan_id        = var.vlan_id
   network_bridge = var.network_bridge
 
+  qemu_agent_enabled = var.qemu_agent_enabled
+
   cloud_init_enabled           = true
   cloud_init_user              = var.cloud_init_user
   cloud_init_ssh_keys          = var.ssh_keys
@@ -89,7 +91,7 @@ module "control_plane" {
 }
 
 module "workers" {
-  source = "git::https://github.com/n2solutionsio/terraform-proxmox-vm.git?ref=v0.3.0"
+  source = "git::https://github.com/n2solutionsio/terraform-proxmox-vm.git?ref=v0.4.0"
   count  = var.worker_count
 
   node_name      = var.node_name
@@ -102,6 +104,8 @@ module "workers" {
   import_from    = proxmox_virtual_environment_download_file.cloud_image.id
   vlan_id        = var.vlan_id
   network_bridge = var.network_bridge
+
+  qemu_agent_enabled = var.qemu_agent_enabled
 
   cloud_init_enabled           = true
   cloud_init_user              = var.cloud_init_user

--- a/templates/k3s-agent.yaml.tftpl
+++ b/templates/k3s-agent.yaml.tftpl
@@ -9,12 +9,11 @@ users:
       - ${key}
 %{ endfor ~}
 package_update: true
-%{ if length(extra_packages) > 0 ~}
 packages:
+  - qemu-guest-agent
 %{ for pkg in extra_packages ~}
   - ${pkg}
 %{ endfor ~}
-%{ endif ~}
 %{ if length(agent_files) > 0 || agent_config_yaml != "" ~}
 write_files:
 %{ if agent_config_yaml != "" ~}
@@ -36,5 +35,6 @@ runcmd:
 %{ for cmd in pre_k3s_commands ~}
   - ${cmd}
 %{ endfor ~}
+  - systemctl enable --now qemu-guest-agent
   - mkdir -p /etc/rancher/k3s
   - curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${k3s_version}" K3S_TOKEN="${k3s_token}" K3S_URL="https://${server_address}:6443" sh -s - agent --node-name ${hostname}%{ for arg in extra_agent_args } ${arg}%{ endfor }

--- a/templates/k3s-server.yaml.tftpl
+++ b/templates/k3s-server.yaml.tftpl
@@ -9,12 +9,11 @@ users:
       - ${key}
 %{ endfor ~}
 package_update: true
-%{ if length(extra_packages) > 0 ~}
 packages:
+  - qemu-guest-agent
 %{ for pkg in extra_packages ~}
   - ${pkg}
 %{ endfor ~}
-%{ endif ~}
 %{ if length(server_files) > 0 || server_config_yaml != "" ~}
 write_files:
 %{ if server_config_yaml != "" ~}
@@ -36,6 +35,7 @@ runcmd:
 %{ for cmd in pre_k3s_commands ~}
   - ${cmd}
 %{ endfor ~}
+  - systemctl enable --now qemu-guest-agent
   - mkdir -p /etc/rancher/k3s
   - curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${k3s_version}" K3S_TOKEN="${k3s_token}" sh -s - server --cluster-init --node-name ${hostname}%{ for c in disable_components } --disable ${c}%{ endfor }%{ for arg in extra_server_args } ${arg}%{ endfor }%{ for t in server_taints } --node-taint ${t}%{ endfor }
 %{ for cmd in post_k3s_commands ~}

--- a/variables.tf
+++ b/variables.tf
@@ -119,6 +119,12 @@ variable "cloud_init_user" {
   default     = "ubuntu"
 }
 
+variable "qemu_agent_enabled" {
+  description = "Enable the QEMU guest agent on all nodes. The qemu-guest-agent package is installed via cloud-init; this toggles the Proxmox-side agent block (a power-cycle is required for the virtio channel to attach)."
+  type        = bool
+  default     = true
+}
+
 variable "snippet_storage" {
   description = "Proxmox storage for cloud-init snippets"
   type        = string


### PR DESCRIPTION
## What
- Bumps the `terraform-proxmox-vm` module **v0.3.0 → v0.4.0** (which added agent support).
- Passes a new **`qemu_agent_enabled`** var (default `true`) to both control-plane and worker VMs.
- cloud-init now **always installs `qemu-guest-agent`** and `systemctl enable --now`s it (both server + agent templates; was previously gated behind `extra_packages`).

## Why
The k3s nodes had no QEMU guest agent (`agent: 0`, package absent). This gives **out-of-band `guest-exec`** via the Proxmox API — the break-glass recovery path we lacked on 2026-06-20 when access looked lost — plus fs-consistent backups, host `fstrim`, and guest IP reporting.

## Rollout (after merge + tag)
1. Tag this repo (next version) so `homelab-live` can bump its ref.
2. `homelab-live` terragrunt ref bump → `terragrunt plan` (**confirm in-place, no VM recreate**) → `apply` (sets `agent: 1`).
3. **Existing nodes** also need the package (cloud-init only runs on new nodes) — install via ansible + **power-cycle each node** (one at a time) to attach the virtio channel. New nodes get everything automatically.

## Validation
`tofu fmt` + `tofu init` (fetches v0.4.0) + `tofu validate` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)