### PR TITLE
Stop image-republish + cloud-init drift from rebuilding k3s nodes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,12 @@ resource "proxmox_virtual_environment_download_file" "cloud_image" {
   url                 = var.cloud_image_url
   file_name           = var.cloud_image_file_name
   overwrite_unmanaged = true
+
+  # Do not re-download / replace the image when the upstream file's size or
+  # checksum changes (Ubuntu re-publishes the same-named cloud image). Without
+  # this, a republished image forces replacement of this resource, which
+  # cascades into disk.import_from and rebuilds every VM.
+  overwrite = false
 }
 
 resource "proxmox_virtual_environment_file" "cloud_init_server" {
@@ -65,7 +71,7 @@ resource "proxmox_virtual_environment_file" "cloud_init_agent" {
 }
 
 module "control_plane" {
-  source = "git::https://github.com/n2solutionsio/terraform-proxmox-vm.git?ref=v0.3.0"
+  source = "git::https://github.com/n2solutionsio/terraform-proxmox-vm.git?ref=v0.3.1"
   count  = var.control_plane_count
 
   node_name      = var.node_name
@@ -89,7 +95,7 @@ module "control_plane" {
 }
 
 module "workers" {
-  source = "git::https://github.com/n2solutionsio/terraform-proxmox-vm.git?ref=v0.3.0"
+  source = "git::https://github.com/n2solutionsio/terraform-proxmox-vm.git?ref=v0.3.1"
   count  = var.worker_count
 
   node_name      = var.node_name


### PR DESCRIPTION
## Why

`terragrunt plan` on a k3s cluster built from this module wants to **destroy/recreate every VM** to apply changes that only matter at first boot — e.g. a worker `cpu.cores 2 -> 4` bump came out as `9 to destroy`. Two force-replacement triggers:

1. **Image republish** — Ubuntu re-publishes the same-named 24.04 cloud image; the size/checksum changes, forcing `proxmox_virtual_environment_download_file.cloud_image` to be replaced, which cascades into each VM's `disk.import_from`.
2. **Cloud-init** — re-rendered snippets change `user_data_file_id`, a force-replacement attribute on the VM.

## Change

- `overwrite = false` on the cloud image download → a republished upstream image no longer forces a re-download/replacement.
- Bump `terraform-proxmox-vm` → **v0.3.1**, which adds `lifecycle.ignore_changes` on `disk[0].import_from` and `initialization[0].user_data_file_id` (see terraform-proxmox-vm#4).

Together these make `plan` reduce to just the intended in-place change (e.g. CPU), `0 to destroy`.

## ⚠️ Merge order
Requires the **`v0.3.1`** tag on `terraform-proxmox-vm` to exist first (this PR references it). Tag that, then merge here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)