### PR TITLE
Freeze cloud-init snippets + bump vm to v0.3.2 (pristine, SSH-free plan)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,14 @@ resource "proxmox_virtual_environment_file" "cloud_init_server" {
     })
     file_name = "${var.cluster_name}-k3s-server-${count.index}.yaml"
   }
+
+  # source_raw.data is write-only in the provider, so it perma-diffs and forces
+  # a destroy/recreate of this snippet on every apply (needing an SSH upload).
+  # Cloud-init only matters at first boot; freeze it so routine applies don't
+  # churn it. To intentionally roll cloud-init, taint this resource.
+  lifecycle {
+    ignore_changes = [source_raw]
+  }
 }
 
 resource "proxmox_virtual_environment_file" "cloud_init_agent" {
@@ -68,10 +76,18 @@ resource "proxmox_virtual_environment_file" "cloud_init_agent" {
     })
     file_name = "${var.cluster_name}-k3s-agent-${count.index}.yaml"
   }
+
+  # source_raw.data is write-only in the provider, so it perma-diffs and forces
+  # a destroy/recreate of this snippet on every apply (needing an SSH upload).
+  # Cloud-init only matters at first boot; freeze it so routine applies don't
+  # churn it. To intentionally roll cloud-init, taint this resource.
+  lifecycle {
+    ignore_changes = [source_raw]
+  }
 }
 
 module "control_plane" {
-  source = "git::https://github.com/n2solutionsio/terraform-proxmox-vm.git?ref=v0.3.1"
+  source = "git::https://github.com/n2solutionsio/terraform-proxmox-vm.git?ref=v0.3.2"
   count  = var.control_plane_count
 
   node_name      = var.node_name
@@ -95,7 +111,7 @@ module "control_plane" {
 }
 
 module "workers" {
-  source = "git::https://github.com/n2solutionsio/terraform-proxmox-vm.git?ref=v0.3.1"
+  source = "git::https://github.com/n2solutionsio/terraform-proxmox-vm.git?ref=v0.3.2"
   count  = var.worker_count
 
   node_name      = var.node_name


### PR DESCRIPTION
## Why
Two remaining sources of non-clean plans / apply failures on a live k3s cluster:
1. **Snippet churn** — `source_raw.data` is write-only in bpg, so it perma-diffs and forces a destroy/recreate of every snippet on each apply (needs an SSH upload).
2. **ide2 failure** — the VM's `initialization.user_account.keys` perma-diff can't be applied to a running VM (rewrites ide2 → Proxmox rejects). Fixed by vm v0.3.2 (ignores the whole `initialization` block).

## Change
- `lifecycle.ignore_changes = [source_raw]` on `cloud_init_server` + `cloud_init_agent`.
- Bump `terraform-proxmox-vm` ref → **v0.3.2**.

## Result
`plan` shows only real in-place changes (e.g. `worker cpu 2→4`); `apply` no longer churns snippets, needs no SSH upload, and never hits the ide2 error. This is the clean baseline the gated CI needs.

Requires the **v0.3.2** tag on terraform-proxmox-vm (PR #5) first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)